### PR TITLE
Update MapSearch.css

### DIFF
--- a/src/components/MapSearch/MapSearch.css
+++ b/src/components/MapSearch/MapSearch.css
@@ -5,6 +5,7 @@
     width: 100%;
     padding: 10px 3rem 10px 0;
     box-sizing: border-box;
+    flex-wrap: wrap;
   }
   
   .input-group {
@@ -13,6 +14,7 @@
     gap: 10px;
     margin-right: auto;
     margin-left: 0;
+    flex-wrap: wrap;
   }
   
   .input-container {
@@ -66,7 +68,7 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    margin-left: auto;
+    /*margin-left: auto;*/
   }
   
   .map-search-button {


### PR DESCRIPTION
added flex wrap to styles to account for smaller screens and mobile layout. Took off margin-left of button group so it wraps under the search bars when on mobile